### PR TITLE
refactor: migrate faker to @faker-js/faker

### DIFF
--- a/initDb.js
+++ b/initDb.js
@@ -24,7 +24,7 @@ const { Assignment } = require('./models/assignment.js');
 const { Submission } = require('./models/submission.js');
 const { Error } = require('./models/error.js');
 const bcrypt = require('bcrypt');
-const faker = require('faker');
+const { faker } = require('@faker-js/faker');
 
 const mongoHost = process.env.MONGO_HOST || 'localhost';
 const mongoPort = process.env.MONGO_PORT || 27017;
@@ -89,17 +89,12 @@ async function createMongoUser(username, password) {
 }
 
 async function generateFakeAssignments(courses, numAssignments) {
-  const fakeAssignments = [];
-  for (let i = 0; i < numAssignments; i++) {
-    const course = courses[Math.floor(Math.random() * courses.length)];
-    fakeAssignments.push({
-      courseId: course._id,
-      title: faker.lorem.words(3),
-      points: faker.random.number({ min: 10, max: 100 }),
-      due: faker.date.future(),
-    });
-  }
-  return fakeAssignments;
+  return faker.helpers.multiple(() => ({    
+    courseId: faker.helpers.arrayElement(courses)._id,
+    title: faker.lorem.words(3),
+    points: faker.number.int({ min: 10, max: 100 }),
+    due: faker.date.future(),
+  }), { count: numAssignments });
 }
 
 async function generateAssignments(numAssignments = 10) {
@@ -119,18 +114,13 @@ async function generateAssignments(numAssignments = 10) {
 
 
 async function generateFakeCourses(instructors, numCourses) {
-  const fakeCourses = [];
-  for (let i = 0; i < numCourses; i++) {
-    const instructor = instructors[Math.floor(Math.random() * instructors.length)];
-    fakeCourses.push({
-      subject: faker.random.arrayElement(['CS', 'MATH', 'PHYS', 'ENG', 'HIST']),
-      title: faker.lorem.words(3),
-      number: faker.random.number({ min: 1000, max: 9999 }).toString(),
-      instructorId: instructor._id,
-      term: faker.random.arrayElement(['sp24', 'su24', 'fa24', 'wi24']),
-    });
-  }
-  return fakeCourses;
+  return faker.helpers.multiple(() => ({
+    subject: faker.helpers.arrayElement(['CS', 'MATH', 'PHYS', 'ENG', 'HIST']),
+    title: faker.lorem.words(3),
+    number: faker.string.numeric({ allowLeadingZeros: false, length: 4 }),
+    instructorId: faker.helpers.arrayElement(instructors)._id,
+    term: faker.helpers.arrayElement(['sp24', 'su24', 'fa24', 'wi24']),
+  }), { cound: numCourses });
 }
 
 async function generateCourses(numCourses = 10) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "license": "Unlicense",
       "dependencies": {
+        "@faker-js/faker": "^9.2.0",
         "bcrypt": "^5.1.1",
         "connect": "^3.2.0",
         "csv-writer": "^1.6.0",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
-        "faker": "^5.5.3",
         "fs": "^0.0.1-security",
         "gridfs": "^1.0.0",
         "js-yaml": "^3.3.0",
@@ -52,6 +52,22 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.2.0.tgz",
+      "integrity": "sha512-ulqQu4KMr1/sTFIYvqSdegHT8NIkt66tFAkugGnHA+1WAfEn6hMzNR+svjXGFRVLnapxvej67Z/LwchFrnLBUg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@jsdevtools/ono": {
@@ -1113,11 +1129,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/faker": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
-      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
   "license": "Unlicense",
   "private": true,
   "dependencies": {
+    "@faker-js/faker": "^9.2.0",
     "bcrypt": "^5.1.1",
     "connect": "^3.2.0",
     "csv-writer": "^1.6.0",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
-    "faker": "^5.5.3",
     "fs": "^0.0.1-security",
     "gridfs": "^1.0.0",
     "js-yaml": "^3.3.0",


### PR DESCRIPTION
## Description

This PR replaces the old `faker` library with the new community-driven `@faker-js/faker` library. The original `faker` library, once a popular choice for generating fake data, became unmaintained in January 2022. In response, the community came together to create `@faker-js/faker`, ensuring continued support and improvements. You can read more about this on our [website](https://fakerjs.dev/about/announcements/2022-01-14.html#i-heard-something-happened-what-s-the-tldr).

For transparency, I want to mention that I'm one of the maintainers of the new library.

We are actively seeking projects that still use the old library. By migrating these projects, we aim to prevent developers from inadvertently using outdated libraries when searching for code examples.
